### PR TITLE
fix bulding of docker image - there is a bug in alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM node:9.4.0-alpine as client
 
 WORKDIR /usr/app/client/
+ENV SASS_BINARY_NAME linux-x64-59
 COPY client/package*.json ./
 RUN npm install -qy
 COPY client/ ./


### PR DESCRIPTION
under alpine linux there is a problem to download node-sass npm dependency
which ends with failure
see https://github.com/sass/node-sass/issues/2535
solved by Pavel by specifying of version in env. variable

Signed-off-by: Stanislav Chlebec <schlebec@frinx.io>