### PR TITLE
Version bump workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: "Bump Version"
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  bump-version:
+    name: "Bump Version on master"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+        with:
+          ref: ${{ github.ref }}
+      - name: "cat package.json"
+        run: cat ./package.json
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@v1"
+        with:
+          node-version: 12
+      - name: "Automated Version Bump"
+        uses: "FRINXio/gh-action-bump-version@master"
+        with:
+          tag-prefix: ''
+        env:
+          PACKAGEJSON_DIR:  'client'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "cat package.json"
+        run: cat ./package.json


### PR DESCRIPTION
Bumps version of **client** (UI) in frinx-uniconfig-ui.

- usual commit bumps the version like 1.0.X
- commit including MINOR-RELEASE keyword (case sensitive) will bump version like 1.X.0, release and tag the version
- commit including MAJOR-RELEASE keyword (case sensitive) will bump version like X.0.0, release and tag the version